### PR TITLE
Fix script syntax in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1072,8 +1072,6 @@ animateBloch();
     if (target) target.classList.add('active');
 }
 
-        }
-
         function selectPlatform(platform) {
             simulation.platform = platform;
             
@@ -1221,7 +1219,6 @@ animateBloch();
             blochCamera.lookAt(0, 0, 0);
             
             blochRenderer = new THREE.WebGLRenderer({ antialias: true });
-            js<br>blochRenderer.setSize(container.clientWidth, container.clientHeight);<br>container.appendChild(blochRenderer.domElement);<br>
             blochRenderer.setSize(container.clientWidth, container.clientHeight);
             container.appendChild(blochRenderer.domElement);
             


### PR DESCRIPTION
## Summary
- remove stray HTML snippet around Bloch renderer setup
- delete unmatched brace after `switchTab` function

## Testing
- `node --check /tmp/script.js`

------
https://chatgpt.com/codex/tasks/task_e_6860834db6ec83279e23aa1bb32d804a