### PR TITLE
Implement Bloch vector arrow

### DIFF
--- a/index.html
+++ b/index.html
@@ -1191,7 +1191,13 @@
             // Update display every 10 steps
             if (Math.floor(simulation.currentTime / simulation.dt) % 10 === 0) {
                 updateMetrics(metrics);
-                updateBlochVector();
+                const rho = math.subset(simulation.densityMatrix, math.index([0,1],[0,1]));
+                const x = 2 * getReal(rho.get([0,1]));
+                const y = -2 * getImaginary(rho.get([0,1]));
+                const z = getReal(rho.get([0,0])) - getReal(rho.get([1,1]));
+                const theta = Math.acos(Math.max(-1, Math.min(1, z)));
+                const phi = Math.atan2(y, x);
+                updateBlochVector(theta, (phi < 0 ? phi + 2 * Math.PI : phi));
                 updateCharts();
             }
             
@@ -1430,8 +1436,9 @@
 
         // === VISUALIZATION ===
         
-        var blochScene, blochCamera, blochRenderer, blochSphere;
-        let dynamicsChart, histogramChart;
+var blochScene, blochCamera, blochRenderer, blochSphere;
+let dynamicsChart, histogramChart;
+let blochVector;      // ArrowHelper referansı
         
         function initializeBlochSphere() {
             const container = document.getElementById('blochContainer');
@@ -1447,6 +1454,7 @@
             blochCamera.position.z = 3;
 
             blochRenderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+            blochRenderer.setPixelRatio(window.devicePixelRatio || 1);   // Retina netliği
             blochRenderer.setSize(container.clientWidth, container.clientHeight);
             blochRenderer.domElement.style.width  = '100%';
             blochRenderer.domElement.style.height = '100%';
@@ -1478,6 +1486,35 @@
             if (blochRenderer && blochScene && blochCamera) {
                 blochRenderer.render(blochScene, blochCamera);
             }
+        }
+
+        // Arrow representing the Bloch vector
+        function updateBlochVector(theta, phi, length = 1.2) {
+            const x = Math.sin(theta) * Math.cos(phi);
+            const y = Math.sin(theta) * Math.sin(phi);
+            const z = Math.cos(theta);
+
+            if (!blochVector) {
+                const initDir = new THREE.Vector3(1, 0, 0);
+                blochVector = new THREE.ArrowHelper(
+                    initDir.clone().normalize(),
+                    new THREE.Vector3(0, 0, 0),
+                    length,
+                    0x00ff00
+                );
+                blochScene.add(blochVector);
+            }
+
+            const dir = new THREE.Vector3(x, y, z).normalize();
+            blochVector.setDirection(dir);
+            blochVector.setLength(length);
+        }
+
+        function blochFromQubit(alpha, beta) {
+            const absA  = Math.abs(alpha);
+            const theta = 2 * Math.acos(absA);
+            const phi   = math.arg(beta) - math.arg(alpha);
+            updateBlochVector(theta, (phi < 0 ? phi + 2 * Math.PI : phi));
         }
 
         function initializeCharts() {
@@ -1741,30 +1778,6 @@ document.getElementById('expLoader').addEventListener('change', async (e) => {
 
   alert('Deney ayarı yüklendi: ' + cfg.title);
 });
-        /* === Bloch vector update === */
-document.getElementById('expLoader').addEventListener('change', async (e) => { /* bu satırdan sonrası varsa dokunma */ });
-
-function updateBlochVector() {
-  if (!simulation.densityMatrix || !blochScene) return;
-
-  // 1. kubitin tek-kubit yoğunluk matrisi
-  const rho = math.subset(simulation.densityMatrix, math.index([0,1],[0,1]));
-  const x = 2 * getReal(rho.get([0,1]));
-  const y = -2 * getImaginary(rho.get([0,1]));
-  const z = getReal(rho.get([0,0])) - getReal(rho.get([1,1]));
-
-  // Küre üzerindeki nokta
-  if (!blochScene.getObjectByName('stateDot')) {
-    const dot = new THREE.Mesh(
-      new THREE.SphereGeometry(0.05, 16, 16),
-      new THREE.MeshBasicMaterial({ color: 0xff00ff })
-    );
-    dot.name = 'stateDot';
-    blochScene.add(dot);
-  }
-  const dot = blochScene.getObjectByName('stateDot');
-  dot.position.set(x, y, z);
-}
 
     </script>
 </body>


### PR DESCRIPTION
## Summary
- keep Bloch renderer DPI aware
- add global `blochVector` reference
- draw Bloch arrow helper and helper for qubit amplitudes
- compute Bloch angles during evolution loop
- remove obsolete dot-update logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a49f7610483279f2d2405ae974652