### PR TITLE
Fix Bloch container selection and style

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,10 +291,15 @@
         }
         #blochContainer {
             width: 100%;
-            height: 400px;
+            height: 420px;
+            position: relative;
             background: rgba(0, 0, 0, 0.7);
             border-radius: 8px;
             margin-bottom: 15px;
+        }
+        #blochContainer canvas {
+            position: absolute;
+            inset: 0;
         }
 
         .loading {
@@ -1441,7 +1446,8 @@ let dynamicsChart, histogramChart;
 let blochVector;      // ArrowHelper referansı
         
         function initializeBlochSphere() {
-            const container = document.getElementById('blochContainer');
+            // Use the (single) container inside the Bloch tab.
+            const container = document.querySelector('#tab-bloch #blochContainer');
 
             blochScene = new THREE.Scene();
 


### PR DESCRIPTION
## Summary
- set the Bloch container query to look inside the tab
- size and position the Bloch canvas using CSS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a5066bc1483278045fad36de4726d